### PR TITLE
Add `sim.h` based intrinsics and correspomding clang builtins 

### DIFF
--- a/clang/include/clang/Basic/BuiltinsSystemS.def
+++ b/clang/include/clang/Basic/BuiltinsSystemS.def
@@ -1,0 +1,15 @@
+// Fixed-point Math Builtins
+BUILTIN(systemSFPSqrt, "ii", "nc")
+BUILTIN(systemSFPSin, "ii", "nc")
+BUILTIN(systemSFPCos, "ii", "nc")
+BUILTIN(systemSFPAtan2, "iii", "nc")
+
+// Graphics Builtins
+BUILTIN(systemSPutPixel, "viii", "nc")
+BUILTIN(systemSFlush, "i", "nc")
+
+// Utility Builtins
+BUILTIN(systemSLog, "vv*", "nc")
+BUILTIN(systemSDeltaTime, "i", "nc")
+
+#undef BUILTIN

--- a/clang/include/clang/Basic/TargetBuiltins.h
+++ b/clang/include/clang/Basic/TargetBuiltins.h
@@ -402,12 +402,22 @@ namespace clang {
     };
   }
 
+  /// SystemS builtins
+  namespace SystemS {
+    enum {
+        LastTIBuiltin = clang::Builtin::FirstTSBuiltin-1,
+#define BUILTIN(ID, TYPE, ATTRS) BI##ID,
+#include "clang/Basic/BuiltinsSystemS.def"
+        LastTSBuiltin
+    };
+  }
+
   static constexpr uint64_t LargestBuiltinID = std::max<uint64_t>(
       {ARM::LastTSBuiltin, AArch64::LastTSBuiltin, BPF::LastTSBuiltin,
        PPC::LastTSBuiltin, NVPTX::LastTSBuiltin, AMDGPU::LastTSBuiltin,
        X86::LastTSBuiltin, VE::LastTSBuiltin, RISCV::LastTSBuiltin,
        Hexagon::LastTSBuiltin, Mips::LastTSBuiltin, XCore::LastTSBuiltin,
-       SystemZ::LastTSBuiltin, WebAssembly::LastTSBuiltin});
+       SystemZ::LastTSBuiltin, WebAssembly::LastTSBuiltin,  SystemS::LastTSBuiltin});
 
 } // end namespace clang.
 

--- a/clang/lib/Basic/CMakeLists.txt
+++ b/clang/lib/Basic/CMakeLists.txt
@@ -114,6 +114,7 @@ add_clang_library(clangBasic
   Targets/RISCV.cpp
   Targets/SPIR.cpp
   Targets/Sparc.cpp
+  Targets/SystemS.cpp
   Targets/SystemZ.cpp
   Targets/TCE.cpp
   Targets/VE.cpp

--- a/clang/lib/Basic/Targets.cpp
+++ b/clang/lib/Basic/Targets.cpp
@@ -34,6 +34,7 @@
 #include "Targets/RISCV.h"
 #include "Targets/SPIR.h"
 #include "Targets/Sparc.h"
+#include "Targets/SystemS.h"
 #include "Targets/SystemZ.h"
 #include "Targets/TCE.h"
 #include "Targets/VE.h"
@@ -455,8 +456,7 @@ std::unique_ptr<TargetInfo> AllocateTarget(const llvm::Triple &Triple,
       return std::make_unique<FuchsiaTargetInfo<RISCV64TargetInfo>>(Triple,
                                                                     Opts);
     case llvm::Triple::Haiku:
-      return std::make_unique<HaikuTargetInfo<RISCV64TargetInfo>>(Triple,
-                                                                  Opts);
+      return std::make_unique<HaikuTargetInfo<RISCV64TargetInfo>>(Triple, Opts);
     case llvm::Triple::Linux:
       switch (Triple.getEnvironment()) {
       default:
@@ -518,7 +518,10 @@ std::unique_ptr<TargetInfo> AllocateTarget(const llvm::Triple &Triple,
       return std::make_unique<SparcV9TargetInfo>(Triple, Opts);
     }
 
-  case llvm::Triple::systemz:
+  case llvm::Triple::systems:
+    return std::make_unique<SystemSTargetInfo>(Triple, Opts);
+
+    case llvm::Triple::systemz:
     switch (os) {
     case llvm::Triple::Linux:
       return std::make_unique<LinuxTargetInfo<SystemZTargetInfo>>(Triple, Opts);
@@ -694,17 +697,17 @@ std::unique_ptr<TargetInfo> AllocateTarget(const llvm::Triple &Triple,
         !Triple.isOSBinFormatWasm())
       return nullptr;
     switch (os) {
-      case llvm::Triple::WASI:
+    case llvm::Triple::WASI:
       return std::make_unique<WASITargetInfo<WebAssembly32TargetInfo>>(Triple,
                                                                        Opts);
-      case llvm::Triple::Emscripten:
+    case llvm::Triple::Emscripten:
       return std::make_unique<EmscriptenTargetInfo<WebAssembly32TargetInfo>>(
           Triple, Opts);
-      case llvm::Triple::UnknownOS:
+    case llvm::Triple::UnknownOS:
       return std::make_unique<WebAssemblyOSTargetInfo<WebAssembly32TargetInfo>>(
           Triple, Opts);
-      default:
-        return nullptr;
+    default:
+      return nullptr;
     }
   case llvm::Triple::wasm64:
     if (Triple.getSubArch() != llvm::Triple::NoSubArch ||
@@ -712,17 +715,17 @@ std::unique_ptr<TargetInfo> AllocateTarget(const llvm::Triple &Triple,
         !Triple.isOSBinFormatWasm())
       return nullptr;
     switch (os) {
-      case llvm::Triple::WASI:
+    case llvm::Triple::WASI:
       return std::make_unique<WASITargetInfo<WebAssembly64TargetInfo>>(Triple,
                                                                        Opts);
-      case llvm::Triple::Emscripten:
+    case llvm::Triple::Emscripten:
       return std::make_unique<EmscriptenTargetInfo<WebAssembly64TargetInfo>>(
           Triple, Opts);
-      case llvm::Triple::UnknownOS:
+    case llvm::Triple::UnknownOS:
       return std::make_unique<WebAssemblyOSTargetInfo<WebAssembly64TargetInfo>>(
           Triple, Opts);
-      default:
-        return nullptr;
+    default:
+      return nullptr;
     }
 
   case llvm::Triple::dxil:
@@ -792,8 +795,7 @@ TargetInfo::CreateTargetInfo(DiagnosticsEngine &Diags,
   }
 
   // Check the TuneCPU name if specified.
-  if (!Opts->TuneCPU.empty() &&
-      !Target->isValidTuneCPUName(Opts->TuneCPU)) {
+  if (!Opts->TuneCPU.empty() && !Target->isValidTuneCPUName(Opts->TuneCPU)) {
     Diags.Report(diag::err_target_unknown_cpu) << Opts->TuneCPU;
     SmallVector<StringRef, 32> ValidList;
     Target->fillValidTuneCPUList(ValidList);

--- a/clang/lib/Basic/Targets/SystemS.cpp
+++ b/clang/lib/Basic/Targets/SystemS.cpp
@@ -1,0 +1,60 @@
+#include "SystemS.h"
+
+#include "clang/Basic/Builtins.h"
+#include "clang/Basic/MacroBuilder.h"
+
+using namespace clang;
+using namespace clang::targets;
+
+clang::targets::SystemSTargetInfo::SystemSTargetInfo(const llvm::Triple &Triple,
+                                                     const TargetOptions &Opts)
+    : TargetInfo(Triple) {
+  NoAsmVariants = true;
+  LongLongAlign = 32;
+  SuitableAlign = 32;
+  DoubleAlign = LongDoubleAlign = 32;
+  SizeType = UnsignedInt;
+  PtrDiffType = SignedInt;
+  IntPtrType = SignedInt;
+  WCharType = UnsignedChar;
+  WIntType = UnsignedInt;
+
+  resetDataLayout("e-m:e-p:32:32-i8:8:32-i16:16:32-i64:64-n32");
+}
+
+bool clang::targets::SystemSTargetInfo::validateAsmConstraint(
+    const char *&Name, TargetInfo::ConstraintInfo &Info) const {
+  return false;
+}
+
+void SystemSTargetInfo::getTargetDefines(const LangOptions &Opts,
+
+                                         MacroBuilder &Builder) const {
+  Builder.defineMacro("__systems_");
+}
+
+ArrayRef<Builtin::Info> SystemSTargetInfo::getTargetBuiltins() const {
+  return std::nullopt;
+}
+
+clang::TargetInfo::BuiltinVaListKind
+clang::targets::SystemSTargetInfo::getBuiltinVaListKind() const {
+  return TargetInfo::VoidPtrBuiltinVaList;
+}
+
+std::string_view clang::targets::SystemSTargetInfo::getClobbers() const {
+  return "";
+}
+
+ArrayRef<const char *>
+clang::targets::SystemSTargetInfo::getGCCRegNames() const {
+  static const char *const GCCRegNames[] = {
+      "r0", "r1", "r2",  "r3",  "r4",  "r5",  "r6",  "r7",
+      "r8", "r9", "r10", "r11", "r12", "r13", "r14", "r15"};
+  return llvm::ArrayRef(GCCRegNames);
+}
+
+ArrayRef<TargetInfo::GCCRegAlias>
+clang::targets::SystemSTargetInfo::getGCCRegAliases() const {
+  return std::nullopt;
+}

--- a/clang/lib/Basic/Targets/SystemS.cpp
+++ b/clang/lib/Basic/Targets/SystemS.cpp
@@ -2,12 +2,26 @@
 
 #include "clang/Basic/Builtins.h"
 #include "clang/Basic/MacroBuilder.h"
+#include "clang/Basic/TargetBuiltins.h"
 
+using namespace llvm;
 using namespace clang;
 using namespace clang::targets;
 
-clang::targets::SystemSTargetInfo::SystemSTargetInfo(const llvm::Triple &Triple,
-                                                     const TargetOptions &Opts)
+namespace {
+
+static constexpr Builtin::Info BuiltinInfo[] = {
+
+#define BUILTIN(ID, TYPE, ATTRS)                                               \
+  {#ID, TYPE, ATTRS, nullptr, HeaderDesc::NO_HEADER, ALL_LANGUAGES},
+#include "clang/Basic/BuiltinsSystemS.def"
+
+};
+
+} // namespace
+
+SystemSTargetInfo::SystemSTargetInfo(const llvm::Triple &Triple,
+                                     const TargetOptions &Opts)
     : TargetInfo(Triple) {
   NoAsmVariants = true;
   LongLongAlign = 32;
@@ -22,39 +36,34 @@ clang::targets::SystemSTargetInfo::SystemSTargetInfo(const llvm::Triple &Triple,
   resetDataLayout("e-m:e-p:32:32-i8:8:32-i16:16:32-i64:64-n32");
 }
 
-bool clang::targets::SystemSTargetInfo::validateAsmConstraint(
+bool SystemSTargetInfo::validateAsmConstraint(
     const char *&Name, TargetInfo::ConstraintInfo &Info) const {
   return false;
 }
 
 void SystemSTargetInfo::getTargetDefines(const LangOptions &Opts,
-
                                          MacroBuilder &Builder) const {
   Builder.defineMacro("__systems_");
 }
 
 ArrayRef<Builtin::Info> SystemSTargetInfo::getTargetBuiltins() const {
-  return std::nullopt;
+  return ArrayRef(BuiltinInfo,
+                  SystemS::LastTSBuiltin - Builtin::FirstTSBuiltin);
 }
 
-clang::TargetInfo::BuiltinVaListKind
-clang::targets::SystemSTargetInfo::getBuiltinVaListKind() const {
+TargetInfo::BuiltinVaListKind SystemSTargetInfo::getBuiltinVaListKind() const {
   return TargetInfo::VoidPtrBuiltinVaList;
 }
 
-std::string_view clang::targets::SystemSTargetInfo::getClobbers() const {
-  return "";
-}
+std::string_view SystemSTargetInfo::getClobbers() const { return ""; }
 
-ArrayRef<const char *>
-clang::targets::SystemSTargetInfo::getGCCRegNames() const {
+ArrayRef<const char *> SystemSTargetInfo::getGCCRegNames() const {
   static const char *const GCCRegNames[] = {
       "r0", "r1", "r2",  "r3",  "r4",  "r5",  "r6",  "r7",
       "r8", "r9", "r10", "r11", "r12", "r13", "r14", "r15"};
-  return llvm::ArrayRef(GCCRegNames);
+  return ArrayRef(GCCRegNames);
 }
 
-ArrayRef<TargetInfo::GCCRegAlias>
-clang::targets::SystemSTargetInfo::getGCCRegAliases() const {
+ArrayRef<TargetInfo::GCCRegAlias> SystemSTargetInfo::getGCCRegAliases() const {
   return std::nullopt;
 }

--- a/clang/lib/Basic/Targets/SystemS.h
+++ b/clang/lib/Basic/Targets/SystemS.h
@@ -1,0 +1,36 @@
+#ifndef LLVM_CLANG_LIB_BASIC_TARGETS_SYSTEMS_H
+#define LLVM_CLANG_LIB_BASIC_TARGETS_SYSTEMS_H
+
+#include "clang/Basic/TargetInfo.h"
+#include "clang/Basic/TargetOptions.h"
+
+#include "llvm/Support/Compiler.h"
+#include "llvm/TargetParser/Triple.h"
+
+namespace clang {
+
+namespace targets {
+
+class LLVM_LIBRARY_VISIBILITY SystemSTargetInfo : public TargetInfo {
+public: /* Constructors and destructors */
+  SystemSTargetInfo(const llvm::Triple &Triple, const TargetOptions &Opts);
+
+public: /* Public API */
+  bool validateAsmConstraint(const char *&Name,
+                             TargetInfo::ConstraintInfo &Info) const override;
+
+public: /* Data getters and setters */
+  void getTargetDefines(const LangOptions &Opts,
+                        MacroBuilder &Builder) const override;
+  ArrayRef<Builtin::Info> getTargetBuiltins() const override;
+  BuiltinVaListKind getBuiltinVaListKind() const override;
+  std::string_view getClobbers() const override;
+  ArrayRef<const char *> getGCCRegNames() const override;
+  ArrayRef<TargetInfo::GCCRegAlias> getGCCRegAliases() const override;
+};
+
+} // namespace targets
+
+} // namespace clang
+
+#endif // LLVM_CLANG_LIB_BASIC_TARGETS_SYSTEMS_H

--- a/clang/lib/Driver/ToolChains/Gnu.cpp
+++ b/clang/lib/Driver/ToolChains/Gnu.cpp
@@ -255,6 +255,8 @@ static const char *getLDMOption(const llvm::Triple &T, const ArgList &Args) {
     return "elf32lriscv";
   case llvm::Triple::riscv64:
     return "elf64lriscv";
+  case llvm::Triple::systems:
+    return "elf32_sim";
   case llvm::Triple::sparc:
   case llvm::Triple::sparcel:
     return "elf32_sparc";
@@ -305,7 +307,7 @@ static bool getStaticPIE(const ArgList &Args, const ToolChain &TC) {
 
 static bool getStatic(const ArgList &Args) {
   return Args.hasArg(options::OPT_static) &&
-      !Args.hasArg(options::OPT_static_pie);
+         !Args.hasArg(options::OPT_static_pie);
 }
 
 void tools::gnutools::StaticLibTool::ConstructJob(
@@ -332,7 +334,7 @@ void tools::gnutools::StaticLibTool::ConstructJob(
 
   for (const auto &II : Inputs) {
     if (II.isFilename()) {
-       CmdArgs.push_back(II.getFilename());
+      CmdArgs.push_back(II.getFilename());
     }
   }
 
@@ -488,8 +490,8 @@ void tools::gnutools::Linker::ConstructJob(Compilation &C, const JobAction &JA,
       std::string P;
       if (ToolChain.GetRuntimeLibType(Args) == ToolChain::RLT_CompilerRT &&
           !isAndroid) {
-        std::string crtbegin = ToolChain.getCompilerRT(Args, "crtbegin",
-                                                       ToolChain::FT_Object);
+        std::string crtbegin =
+            ToolChain.getCompilerRT(Args, "crtbegin", ToolChain::FT_Object);
         if (ToolChain.getVFS().exists(crtbegin))
           P = crtbegin;
       }
@@ -649,8 +651,8 @@ void tools::gnutools::Linker::ConstructJob(Compilation &C, const JobAction &JA,
         std::string P;
         if (ToolChain.GetRuntimeLibType(Args) == ToolChain::RLT_CompilerRT &&
             !isAndroid) {
-          std::string crtend = ToolChain.getCompilerRT(Args, "crtend",
-                                                       ToolChain::FT_Object);
+          std::string crtend =
+              ToolChain.getCompilerRT(Args, "crtend", ToolChain::FT_Object);
           if (ToolChain.getVFS().exists(crtend))
             P = crtend;
         }
@@ -811,7 +813,8 @@ void tools::gnutools::Assembler::ConstructJob(Compilation &C,
     }
 
     switch (arm::getARMFloatABI(getToolChain(), Args)) {
-    case arm::FloatABI::Invalid: llvm_unreachable("must have an ABI!");
+    case arm::FloatABI::Invalid:
+      llvm_unreachable("must have an ABI!");
     case arm::FloatABI::Soft:
       CmdArgs.push_back(Args.MakeArgString("-mfloat-abi=soft"));
       break;
@@ -1574,12 +1577,13 @@ static void findAndroidArmMultilibs(const Driver &D,
   bool IsArmArch = TargetTriple.getArch() == llvm::Triple::arm;
   bool IsThumbArch = TargetTriple.getArch() == llvm::Triple::thumb;
   bool IsV7SubArch = TargetTriple.getSubArch() == llvm::Triple::ARMSubArch_v7;
-  bool IsThumbMode = IsThumbArch ||
+  bool IsThumbMode =
+      IsThumbArch ||
       Args.hasFlag(options::OPT_mthumb, options::OPT_mno_thumb, false) ||
       (IsArmArch && llvm::ARM::parseArchISA(Arch) == llvm::ARM::ISAKind::THUMB);
-  bool IsArmV7Mode = (IsArmArch || IsThumbArch) &&
-      (llvm::ARM::parseArchVersion(Arch) == 7 ||
-       (IsArmArch && Arch == "" && IsV7SubArch));
+  bool IsArmV7Mode =
+      (IsArmArch || IsThumbArch) && (llvm::ARM::parseArchVersion(Arch) == 7 ||
+                                     (IsArmArch && Arch == "" && IsV7SubArch));
   addMultilibFlag(IsArmV7Mode, "-march=armv7-a", Flags);
   addMultilibFlag(IsThumbMode, "-mthumb", Flags);
 
@@ -2423,10 +2427,9 @@ void Generic_GCC::GCCInstallationDetector::AddDefaultGCCPrefixes(
 
   static const char *const ARMLibDirs[] = {"/lib"};
   static const char *const ARMTriples[] = {"arm-linux-gnueabi"};
-  static const char *const ARMHFTriples[] = {"arm-linux-gnueabihf",
-                                             "armv7hl-redhat-linux-gnueabi",
-                                             "armv6hl-suse-linux-gnueabi",
-                                             "armv7hl-suse-linux-gnueabi"};
+  static const char *const ARMHFTriples[] = {
+      "arm-linux-gnueabihf", "armv7hl-redhat-linux-gnueabi",
+      "armv6hl-suse-linux-gnueabi", "armv7hl-suse-linux-gnueabi"};
   static const char *const ARMebLibDirs[] = {"/lib"};
   static const char *const ARMebTriples[] = {"armeb-linux-gnueabi"};
   static const char *const ARMebHFTriples[] = {
@@ -2814,8 +2817,8 @@ void Generic_GCC::GCCInstallationDetector::AddDefaultGCCPrefixes(
 }
 
 bool Generic_GCC::GCCInstallationDetector::ScanGCCForMultilibs(
-    const llvm::Triple &TargetTriple, const ArgList &Args,
-    StringRef Path, bool NeedsBiarchSuffix) {
+    const llvm::Triple &TargetTriple, const ArgList &Args, StringRef Path,
+    bool NeedsBiarchSuffix) {
   llvm::Triple::ArchType TargetArch = TargetTriple.getArch();
   DetectedMultilibs Detected;
 
@@ -2978,8 +2981,8 @@ bool Generic_GCC::GCCInstallationDetector::ScanGentooGccConfig(
         }
       }
       // Test the path based on the version in /etc/env.d/gcc/config-{tuple}.
-      std::string basePath = "/usr/lib/gcc/" + ActiveVersion.first.str() + "/"
-          + ActiveVersion.second.str();
+      std::string basePath = "/usr/lib/gcc/" + ActiveVersion.first.str() + "/" +
+                             ActiveVersion.second.str();
       GentooScanPaths.push_back(StringRef(basePath));
 
       // Scan all paths for GCC libraries.
@@ -3107,8 +3110,7 @@ void Generic_GCC::PushPPaths(ToolChain::path_list &PPaths) {
   }
 }
 
-void Generic_GCC::AddMultilibPaths(const Driver &D,
-                                   const std::string &SysRoot,
+void Generic_GCC::AddMultilibPaths(const Driver &D, const std::string &SysRoot,
                                    const std::string &OSLibDir,
                                    const std::string &MultiarchTriple,
                                    path_list &Paths) {
@@ -3173,8 +3175,7 @@ void Generic_GCC::AddMultilibPaths(const Driver &D,
   }
 }
 
-void Generic_GCC::AddMultiarchPaths(const Driver &D,
-                                    const std::string &SysRoot,
+void Generic_GCC::AddMultiarchPaths(const Driver &D, const std::string &SysRoot,
                                     const std::string &OSLibDir,
                                     path_list &Paths) {
   if (GCCInstallation.isValid()) {
@@ -3184,7 +3185,7 @@ void Generic_GCC::AddMultiarchPaths(const Driver &D,
     const Multilib &Multilib = GCCInstallation.getMultilib();
     addPathIfExists(
         D, LibPath + "/../" + GCCTriple.str() + "/lib" + Multilib.osSuffix(),
-                    Paths);
+        Paths);
   }
 }
 
@@ -3229,9 +3230,9 @@ void Generic_GCC::addSYCLIncludeArgs(const ArgList &DriverArgs,
   SYCLInstallation->addSYCLIncludeArgs(DriverArgs, CC1Args);
 }
 
-void
-Generic_GCC::addLibCxxIncludePaths(const llvm::opt::ArgList &DriverArgs,
-                                   llvm::opt::ArgStringList &CC1Args) const {
+void Generic_GCC::addLibCxxIncludePaths(
+    const llvm::opt::ArgList &DriverArgs,
+    llvm::opt::ArgStringList &CC1Args) const {
   const Driver &D = getDriver();
   std::string SysRoot = computeSysRoot();
   if (SysRoot.empty())
@@ -3378,9 +3379,9 @@ bool Generic_GCC::addGCCLibStdCxxIncludePaths(
   return false;
 }
 
-void
-Generic_GCC::addLibStdCxxIncludePaths(const llvm::opt::ArgList &DriverArgs,
-                                      llvm::opt::ArgStringList &CC1Args) const {
+void Generic_GCC::addLibStdCxxIncludePaths(
+    const llvm::opt::ArgList &DriverArgs,
+    llvm::opt::ArgStringList &CC1Args) const {
   if (GCCInstallation.isValid()) {
     addGCCLibStdCxxIncludePaths(DriverArgs, CC1Args,
                                 GCCInstallation.getTriple().str());

--- a/llvm/include/llvm/IR/CMakeLists.txt
+++ b/llvm/include/llvm/IR/CMakeLists.txt
@@ -22,4 +22,5 @@ tablegen(LLVM IntrinsicsWebAssembly.h -gen-intrinsic-enums -intrinsic-prefix=was
 tablegen(LLVM IntrinsicsX86.h -gen-intrinsic-enums -intrinsic-prefix=x86)
 tablegen(LLVM IntrinsicsXCore.h -gen-intrinsic-enums -intrinsic-prefix=xcore)
 tablegen(LLVM IntrinsicsVE.h -gen-intrinsic-enums -intrinsic-prefix=ve)
+tablegen(LLVM IntrinsicsSystemS.h -gen-intrinsic-enums -intrinsic-prefix=systems)
 add_public_tablegen_target(intrinsics_gen)

--- a/llvm/include/llvm/IR/Intrinsics.td
+++ b/llvm/include/llvm/IR/Intrinsics.td
@@ -2817,5 +2817,6 @@ include "llvm/IR/IntrinsicsSPIRV.td"
 include "llvm/IR/IntrinsicsVE.td"
 include "llvm/IR/IntrinsicsDirectX.td"
 include "llvm/IR/IntrinsicsLoongArch.td"
+include "llvm/IR/IntrinsicsSystemS.td"
 
 #endif // TEST_INTRINSICS_SUPPRESS_DEFS

--- a/llvm/include/llvm/IR/IntrinsicsSystemS.td
+++ b/llvm/include/llvm/IR/IntrinsicsSystemS.td
@@ -1,0 +1,25 @@
+let TargetPrefix = "systems" in {  // All intrinsics start with "llvm.systems.".
+
+  // Fixed-point math intrinsics
+  def int_systems_fpsqrt  : Intrinsic<[llvm_i32_ty], [llvm_i32_ty], 
+                                      [IntrNoMem]>;
+  def int_systems_fpsin   : Intrinsic<[llvm_i32_ty], [llvm_i32_ty], 
+                                      [IntrNoMem]>;
+  def int_systems_fpcos   : Intrinsic<[llvm_i32_ty], [llvm_i32_ty], 
+                                      [IntrNoMem]>;
+  def int_systems_fpatan2 : Intrinsic<[llvm_i32_ty], [llvm_i32_ty, llvm_i32_ty], 
+                                      [IntrNoMem]>;
+  
+  // Graphics intrinsics
+  def int_systems_putpixel : Intrinsic<[], [llvm_i32_ty, llvm_i32_ty, llvm_i32_ty], 
+                                       [IntrHasSideEffects]>;
+  def int_systems_flush    : Intrinsic<[llvm_i32_ty], [], 
+                                       [IntrHasSideEffects]>;
+  
+  // Utility intrinsics 
+  def int_systems_log       : Intrinsic<[], [llvm_anyptr_ty], 
+                                        [IntrHasSideEffects]>;
+  def int_systems_deltatime : Intrinsic<[llvm_i32_ty], [], 
+                                        [IntrNoMem]>;
+
+} // TargetPrefix = "systems"

--- a/llvm/include/llvm/IR/IntrinsicsSystemS.td
+++ b/llvm/include/llvm/IR/IntrinsicsSystemS.td
@@ -1,25 +1,33 @@
 let TargetPrefix = "systems" in {  // All intrinsics start with "llvm.systems.".
 
   // Fixed-point math intrinsics
-  def int_systems_fpsqrt  : Intrinsic<[llvm_i32_ty], [llvm_i32_ty], 
-                                      [IntrNoMem]>;
-  def int_systems_fpsin   : Intrinsic<[llvm_i32_ty], [llvm_i32_ty], 
-                                      [IntrNoMem]>;
-  def int_systems_fpcos   : Intrinsic<[llvm_i32_ty], [llvm_i32_ty], 
-                                      [IntrNoMem]>;
-  def int_systems_fpatan2 : Intrinsic<[llvm_i32_ty], [llvm_i32_ty, llvm_i32_ty], 
-                                      [IntrNoMem]>;
+  def int_systems_fpsqrt  : ClangBuiltin<"systemSFPSqrt">,
+    Intrinsic<[llvm_i32_ty], [llvm_i32_ty], 
+              [IntrNoMem]>;
+  def int_systems_fpsin   : ClangBuiltin<"systemSFPSin">,
+    Intrinsic<[llvm_i32_ty], [llvm_i32_ty], 
+              [IntrNoMem]>;
+  def int_systems_fpcos   : ClangBuiltin<"systemSFPCos">,
+    Intrinsic<[llvm_i32_ty], [llvm_i32_ty], 
+              [IntrNoMem]>;
+  def int_systems_fpatan2 : ClangBuiltin<"systemSFPAtan2">,
+    Intrinsic<[llvm_i32_ty], [llvm_i32_ty, llvm_i32_ty], 
+              [IntrNoMem]>;
   
   // Graphics intrinsics
-  def int_systems_putpixel : Intrinsic<[], [llvm_i32_ty, llvm_i32_ty, llvm_i32_ty], 
-                                       [IntrHasSideEffects]>;
-  def int_systems_flush    : Intrinsic<[llvm_i32_ty], [], 
-                                       [IntrHasSideEffects]>;
+  def int_systems_putpixel : ClangBuiltin<"systemSPutPixel">,
+    Intrinsic<[], [llvm_i32_ty, llvm_i32_ty, llvm_i32_ty], 
+              [IntrHasSideEffects]>;
+  def int_systems_flush    : ClangBuiltin<"systemSFlush">,
+    Intrinsic<[llvm_i32_ty], [], 
+              [IntrHasSideEffects]>;
   
   // Utility intrinsics 
-  def int_systems_log       : Intrinsic<[], [llvm_anyptr_ty], 
-                                        [IntrHasSideEffects]>;
-  def int_systems_deltatime : Intrinsic<[llvm_i32_ty], [], 
-                                        [IntrNoMem]>;
+  def int_systems_log       : ClangBuiltin<"systemSLog">,
+    Intrinsic<[], [llvm_ptr_ty], 
+              [IntrHasSideEffects]>;
+  def int_systems_deltatime : ClangBuiltin<"systemSDeltaTime">,
+    Intrinsic<[llvm_i32_ty], [], 
+              [IntrNoMem]>;
 
 } // TargetPrefix = "systems"

--- a/llvm/lib/IR/Intrinsics.cpp
+++ b/llvm/lib/IR/Intrinsics.cpp
@@ -29,6 +29,7 @@
 #include "llvm/IR/IntrinsicsVE.h"
 #include "llvm/IR/IntrinsicsX86.h"
 #include "llvm/IR/IntrinsicsXCore.h"
+#include "llvm/IR/IntrinsicsSystemS.h"
 #include "llvm/IR/Module.h"
 #include "llvm/IR/Type.h"
 

--- a/llvm/lib/Target/SystemS/CMakeLists.txt
+++ b/llvm/lib/Target/SystemS/CMakeLists.txt
@@ -34,6 +34,5 @@ add_llvm_target(SystemSCodeGen
   SystemS
   )
 
-
 add_subdirectory(MCTargetDesc)
 add_subdirectory(TargetInfo)

--- a/llvm/lib/Target/SystemS/SystemSInstrFormats.td
+++ b/llvm/lib/Target/SystemS/SystemSInstrFormats.td
@@ -36,7 +36,6 @@ class SystemSInst<bits<8> op, dag outs, dag ins, string asmstr, list<dag> patter
   let InOperandList  = ins;
   let AsmString   = asmstr;
   let Pattern     = pattern;
-
 }
 
 // Pseudo instructions format

--- a/llvm/lib/Target/SystemS/SystemSInstrInfo.td
+++ b/llvm/lib/Target/SystemS/SystemSInstrInfo.td
@@ -72,3 +72,75 @@ def MOVLI : SystemSInst<
   "li $r1 $r3_imm",
   [(set GPR:$r1, systemsm16:$r3_imm)]
 >;
+
+// Fixed-point math instructions
+let r3_imm = 0 in {
+def FPSQRT : SystemSInst<
+  0xC0,
+  (outs GPR:$r1),
+  (ins GPR:$r2),
+  "fpsqrt $r1, $r2",
+  [(set GPR:$r1, (int_systems_fpsqrt GPR:$r2))]
+>;
+
+def FPSIN : SystemSInst<
+  0xC1,
+  (outs GPR:$r1),
+  (ins GPR:$r2),
+  "fpsin $r1, $r2",
+  [(set GPR:$r1, (int_systems_fpsin GPR:$r2))]
+>;
+
+def FPCOS : SystemSInst<
+  0xC2,
+  (outs GPR:$r1),
+  (ins GPR:$r2),
+  "fpcos $r1, $r2",
+  [(set GPR:$r1, (int_systems_fpcos GPR:$r2))]
+>;
+} // End let r3_imm = 0
+
+def FPATAN2 : SystemSInst<
+  0xC2,
+  (outs GPR:$r1),
+  (ins GPR:$r2, GPR:$r3_imm),
+  "fpatan2 $r1, $r2, $r3_imm",
+  [(set GPR:$r1, (int_systems_fpatan2 GPR:$r2, GPR:$r3_imm))]
+>;
+
+// Graphics instructions
+def PUTPIXEL : SystemSInst<
+  0xEE,
+  (outs),
+  (ins GPR:$r1, GPR:$r2, GPR:$r3_imm),
+  "putpixel $r1, $r2, $r3_imm",
+  [(int_systems_putpixel GPR:$r1, GPR:$r2, GPR:$r3_imm)]
+>;
+
+let r2 = 0, r3_imm = 0 in
+def FLUSH : SystemSInst<
+  0xEF,
+  (outs GPR:$r1),
+  (ins),
+  "flush $r1",
+  [(set GPR:$r1, (int_systems_flush))]
+>;
+
+// Utility instructions
+let r2 = 0, r3_imm = 0 in {
+def LOG : SystemSInst<
+  0xF0,
+  (outs),
+  (ins GPR:$r1),
+  "log $r1",
+  [(int_systems_log GPR:$r1)]
+>;
+
+def DELTATIME : SystemSInst<
+  0xF1,
+  (outs GPR:$r1),
+  (ins),
+  "deltatime $r1",
+  [(set GPR:$r1, (int_systems_deltatime))]
+>;
+} // End let r2 = 0, r3_imm = 0

--- a/llvm/test/CodeGen/SystemS/clang-intrinsics.c
+++ b/llvm/test/CodeGen/SystemS/clang-intrinsics.c
@@ -1,0 +1,37 @@
+// RUN: %clang -Xclang -triple=systems -S -emit-llvm %s -o - | FileCheck %s --check-prefix=CHECK-IR
+// RUN: %clang -Xclang -triple=systems -S %s -o - | FileCheck %s --check-prefix=CHECK-ASM
+
+#include <stdint.h>
+
+typedef int32_t sim_fp;
+
+void test_graphics() {
+  // CHECK-IR: call void @llvm.systems.putpixel
+  // CHECK-ASM: putpixel
+  systemSPutPixel(100, 200, 0xFF);
+  
+  // CHECK-IR: call i32 @llvm.systems.flush()
+  // CHECK-ASM: flush
+  systemSFlush();
+}
+
+void test_math() {
+  // CHECK-IR: call i32 @llvm.systems.fpsqrt
+  systemSFPSqrt(1);
+  
+  // CHECK-IR: call i32 @llvm.systems.fpsin
+  systemSFPSin(2);
+  
+  // CHECK-IR: call i32 @llvm.systems.fpcos
+  systemSFPCos(1);
+  
+  // CHECK-IR: call i32 @llvm.systems.fpatan2
+  systemSFPAtan2(1, 1);
+}
+
+void test_utilities() {
+  // CHECK-IR: call i32 @llvm.systems.deltatime()
+  // CHECK-ASM: deltatime
+  systemSLog((char *)0x1);
+  systemSDeltaTime();
+}

--- a/llvm/test/CodeGen/SystemS/clang-triples.c
+++ b/llvm/test/CodeGen/SystemS/clang-triples.c
@@ -1,0 +1,2 @@
+// RUN: %clang -print-targets | FileCheck %s 
+// CHECK: systems

--- a/llvm/test/CodeGen/SystemS/intrinsics-graphics.ll
+++ b/llvm/test/CodeGen/SystemS/intrinsics-graphics.ll
@@ -1,0 +1,15 @@
+; RUN: llc < %s -mtriple=systems | FileCheck %s
+
+define i32 @test_flush() nounwind {
+; CHECK-LABEL: test_flush:
+; CHECK: flush {{.*}}
+  %1 = call i32 @llvm.systems.flush()
+  ret i32 %1
+}
+
+define void @test_putpixel(i32 %x, i32 %y, i32 %color) nounwind {
+; CHECK-LABEL: test_putpixel:
+; CHECK: putpixel {{.*}}, {{.*}}, {{.*}}
+  call void @llvm.systems.putpixel(i32 %x, i32 %y, i32 %color)
+  ret void
+}

--- a/llvm/test/CodeGen/SystemS/intrinsics-math.ll
+++ b/llvm/test/CodeGen/SystemS/intrinsics-math.ll
@@ -1,0 +1,29 @@
+; RUN: llc < %s -mtriple=systems | FileCheck %s
+
+define i32 @test_fpsqrt(i32 %a) nounwind {
+; CHECK-LABEL: test_fpsqrt:
+; CHECK: fpsqrt r{{[0-9]+}}, r{{[0-9]+}}
+  %1 = call i32 @llvm.systems.fpsqrt(i32 %a)
+  ret i32 %1
+}
+
+define i32 @test_fpsin(i32 %a) nounwind {
+; CHECK-LABEL: test_fpsin:
+; CHECK: fpsin r{{[0-9]+}}, r{{[0-9]+}}
+  %1 = call i32 @llvm.systems.fpsin(i32 %a)
+  ret i32 %1
+}
+
+define i32 @test_fpcos(i32 %a) nounwind {
+; CHECK-LABEL: test_fpcos:
+; CHECK: fpcos r{{[0-9]+}}, r{{[0-9]+}}
+  %1 = call i32 @llvm.systems.fpcos(i32 %a)
+  ret i32 %1
+}
+
+define i32 @test_fpatan2(i32 %a, i32 %b) nounwind {
+; CHECK-LABEL: test_fpatan2:
+; CHECK: atan2 r{{[0-9]+}}, r{{[0-9]+}}, r{{[0-9]+}}
+  %1 = call i32 @llvm.systems.fpatan2(i32 %a, i32 %b)
+  ret i32 %1
+}

--- a/llvm/test/CodeGen/SystemS/intrinsics-utility.ll
+++ b/llvm/test/CodeGen/SystemS/intrinsics-utility.ll
@@ -1,0 +1,15 @@
+; RUN: llc < %s -mtriple=systems | FileCheck %s
+
+define void @test_log(ptr %0) nounwind {
+; CHECK-LABEL: test_log:
+; CHECK: log r{{[0-9]+}}
+  call void @llvm.systems.log(ptr %0)
+  ret void
+}
+
+define i32 @test_deltatime() nounwind {
+; CHECK-LABEL: test_deltatime:
+; CHECK: deltatime r{{[0-9]+}}
+  %1 = call i32 @llvm.systems.deltatime()
+  ret i32 %1
+}

--- a/llvm/test/CodeGen/SystemS/lit.local.cfg
+++ b/llvm/test/CodeGen/SystemS/lit.local.cfg
@@ -1,2 +1,6 @@
 if not "SystemS" in config.root.targets:
     config.unsupported = True
+
+config.substitutions.append(
+    ('%clang', os.path.join(config.llvm_tools_dir, 'clang'))
+)


### PR DESCRIPTION
Intrinsics set is based on [`sim`](https://github.com/sabitov-kirill/llvm-course/blob/master/sim/src/sim.h) library, used to create graphical application, with minor differences:
- `log` function is no longer variadic and won't support formatting (currently the only argument is string pointer, but it could be replaced with integer for simplicity) 
- vector and matrix manipulations are currently not supported 